### PR TITLE
[김동하-1주차 알고리즘 스터디]

### DIFF
--- a/김동하/1주차/[Baekjoon-10844] 쉬운 계단 수.java
+++ b/김동하/1주차/[Baekjoon-10844] 쉬운 계단 수.java
@@ -1,0 +1,36 @@
+package baekjoon;
+
+import java.util.Scanner;
+
+
+public class Main {
+	public static int dp[][] = new int[101][10];
+	public static Scanner sc = new Scanner(System.in);
+	public static int n;
+	public static void init() {
+		n = sc.nextInt();
+		for(int i = 1; i < 10; i++) {
+			dp[1][i] = 1;
+		}
+	}
+	
+	public static void solution() {
+		init();
+
+		for(int i = 2; i <= n; i++) {
+			for(int j = 0; j < 10; j++) {
+				if(j == 0) dp[i][j] = dp[i - 1][j + 1];
+				else if(j == 9) dp[i][j] = dp[i - 1][j - 1];
+				else dp[i][j] = (dp[i - 1][j -1] + dp[i - 1][j + 1]) % 1000000000;
+			}
+		}
+		int ans = 0;
+		for(int i = 0; i < 10; i++) {
+			ans = (ans + dp[n][i]) % 1000000000;
+		}
+		System.out.println(ans);
+	}
+	public static void main(String[] args) {
+		solution();
+	}
+}

--- a/김동하/1주차/[Baekjoon-17070] 파이프 옮기기 1.java
+++ b/김동하/1주차/[Baekjoon-17070] 파이프 옮기기 1.java
@@ -1,0 +1,69 @@
+package baekjoon;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+
+
+public class Main {
+	public static Scanner sc = new Scanner(System.in);
+	public static int n;
+	public static int[][] arr = new int[17][17];
+	public static void init() {
+		n = sc.nextInt();
+		for(int i = 1; i <= n; i++) {
+			for(int j = 1; j <= n; j++) {
+				arr[i][j] = sc.nextInt();
+			}
+		}
+	}
+	public static boolean OOB(int x, int y) {
+		if(x > n || x < 1 || y > n || y < 1 || arr[x][y] == 1) return true;
+		return false;
+	}
+	static class Node{
+		int x,y,dir;
+		public Node(int x, int y, int dir) {
+			this.x = x;
+			this.y = y;
+			this.dir = dir;
+		}
+	}
+	// 0 : 가로 , 1 : 세로, 2 : 대각선
+	public static int[] dx = {0,1,1};
+	public static int[] dy = {1,0,1};
+	public static int ans = 0;
+	public static void bfs() {
+		Queue<Node> q = new LinkedList<>();
+		q.add(new Node(1,2,0));
+		while(!q.isEmpty()) {
+			int x = q.peek().x;
+			int y = q.peek().y;
+			int d = q.peek().dir;
+			q.remove();
+			if(x == n && y == n) {
+				ans++;
+			}
+			for(int i = 0; i < 3; i++) {
+				int nx = x + dx[i];
+				int ny = y + dy[i];
+				if(i == 2) {
+					if(arr[nx][ny - 1] == 1 || arr[nx - 1][ny] == 1) continue;
+				}
+				if(OOB(nx,ny)) continue;
+				if(d == 0 && i == 1) continue;
+				if(d == 1 && i == 0) continue;
+				q.add(new Node(nx,ny,i));
+			}
+		}
+	}
+
+	public static void solution() {
+		init();
+		bfs();
+		System.out.println(ans);
+	}
+	public static void main(String[] args) {
+		solution();
+	}
+}

--- a/김동하/1주차/[Baekjoon-17471] 게리맨더링.java
+++ b/김동하/1주차/[Baekjoon-17471] 게리맨더링.java
@@ -1,0 +1,98 @@
+package baekjoon;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Scanner;
+
+
+public class Main {
+	public static Scanner sc = new Scanner(System.in);
+	public static int n;
+	public static int area[] = new int[11];
+	public static List<List<Integer>> adj = new ArrayList<>();
+	public static boolean[] isContain = new boolean[11];
+	public static int ans = Integer.MAX_VALUE;
+	public static int sum = 0;
+	public static void init() {
+		n = sc.nextInt();
+		for(int i = 1; i <= n; i++) {
+			area[i] = sc.nextInt();
+			sum += area[i];
+		}
+		for(int i = 1; i <= n; i++) {
+			int k = sc.nextInt();
+			List<Integer> newList = new ArrayList<>();
+			for(int j = 0; j < k; j++) {
+				int x = sc.nextInt();
+				newList.add(x);
+			}
+			adj.add(newList);
+		}
+	}
+	
+	public static boolean bfs(List<Integer> list) {
+		if(list.isEmpty()) return false;
+		Queue<Integer> q = new ArrayDeque<>();
+		q.add(list.get(0));
+		int cnt = 1;
+		boolean[] visited = new boolean[11];
+		visited[list.get(0)] = true;
+		while(!q.isEmpty()) {
+			int x = q.peek();
+			q.remove();
+			for(int i = 0; i < adj.get(x - 1).size(); i++) {
+				int y = adj.get(x - 1).get(i);
+				if(list.contains(y) && !visited[y]) {
+					q.add(y);
+					visited[y] = true;
+					cnt++;
+				}
+			}
+		}
+		if(cnt == list.size()) {
+			return true;
+		}
+		return false;
+	}
+	
+	public static void devide(int idx) {
+		if(idx == n) { 
+			List<Integer> list1 = new ArrayList<>();
+			List<Integer> list2 = new ArrayList<>();
+			for(int i = 1; i <= n; i++) {
+				if(isContain[i]) list1.add(i);
+				else list2.add(i);
+			}
+			
+			if(bfs(list1) && bfs(list2)) {
+				int sum1 = 0;
+				int sum2 = 0;
+				for(int i : list1) {
+					sum1 += area[i];
+				}
+				sum2 = sum - sum1;
+				ans = Math.min(ans, Math.abs(sum1 - sum2));	
+			}
+			return;
+		}
+		isContain[idx + 1] = true;
+		devide(idx + 1);
+		isContain[idx + 1] = false;
+		devide(idx + 1);
+	}
+	
+	public static void solution() {
+		init();
+		isContain[1] = true;
+		devide(1);
+		isContain[1] = false;
+		devide(1);
+		if(ans == Integer.MAX_VALUE)System.out.println(-1);
+		else System.out.println(ans);
+	}
+	public static void main(String[] args) {
+		solution();
+	}
+}

--- a/김동하/1주차/[Baekjoon-17472] 다리 만들기 2.java
+++ b/김동하/1주차/[Baekjoon-17472] 다리 만들기 2.java
@@ -1,0 +1,211 @@
+package baekjoon;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Scanner;
+
+
+public class Main {
+	public static Scanner sc = new Scanner(System.in);
+	public static int n,m;
+	public static int arr[][] = new int[11][11];
+	public static boolean visited[][] = new boolean[11][11];
+	public static int dx[] = {1,0,-1,0};
+	public static int dy[] = {0,1,0,-1};
+	public static int landSize = 0;
+	public static void init() {
+		n = sc.nextInt();
+		m = sc.nextInt();
+		for(int i = 1; i <= 6; i++) {
+			parent[i] = i;
+		}
+		for(int i = 1; i <= n; i++) {
+			for(int j = 1; j <= m; j++) {
+				arr[i][j] = sc.nextInt();
+			}
+		}
+	}
+	public static boolean OOB(int x, int y) {
+		if(x > n || x < 1 || y > m || y < 1) return true;
+		return false;
+	}
+	static class Node{
+		int x,y;
+		public Node(int x, int y) {
+			this.x = x;
+			this.y = y;
+		}
+		public Node() {};
+	}
+	public static List<List<Node>> lands = new ArrayList<>();
+	public static int parent[] = new int[7];
+	public static void bfs(int a, int b) {
+		Queue<Node> q = new LinkedList<>();
+		q.add(new Node(a,b));
+		List<Node> land = new ArrayList<>();
+		land.add(new Node(a,b));
+		visited[a][b] = true;
+		while(!q.isEmpty()) {
+			int x = q.peek().x;
+			int y = q.peek().y;
+		
+			q.remove();
+			for(int i = 0; i < 4; i++) {
+				int nx = x + dx[i];
+				int ny = y + dy[i];
+				if(OOB(nx,ny) || visited[nx][ny] || arr[nx][ny] == 0) continue;
+				visited[nx][ny] = true;
+				land.add(new Node(nx,ny));
+				q.add(new Node(nx,ny));
+			}
+		}
+		lands.add(land);
+	}
+	public static void addLand() {
+		for(int i = 1; i <= n; i++) {
+			for(int j = 1; j <= m; j++) {
+				if(arr[i][j] == 1 && !visited[i][j]) {
+					bfs(i,j);
+					landSize++;
+				}
+			}
+		}
+	}
+	static class Route{
+		int idx1, idx2, size;
+		public Route(int idx1, int idx2, int size) {
+			this.idx1 = idx1;
+			this.idx2 = idx2;
+			this.size = size;
+		}
+	}
+	
+	public static int findParent(int x) {
+		if(x == parent[x]) return x;
+		return findParent(parent[x]);
+	}
+	
+	public static void unionParent(int x, int y) {
+		x = findParent(x);
+		y = findParent(y);
+		if(x > y) parent[x] = y;
+		else parent[y] = x;
+	}
+	
+	public static boolean isAllUnion() {
+		int tmp = findParent(1);
+		for(int i = 2; i <= landSize; i++) {
+			if(tmp != findParent(i)) return  false;
+		}
+		return true;
+	}
+	
+	public static PriorityQueue<Route> route = new PriorityQueue<>((o1,o2) -> Integer.compare(o1.size,o2.size));
+	public static void findRoute(int idx1, int idx2) {
+		List<Node> land1 = lands.get(idx1);
+		List<Node> land2 = lands.get(idx2);
+		int cnt = Integer.MAX_VALUE;
+		for(int i = 0; i < land1.size(); i++) {
+			int x1 = land1.get(i).x;
+			int y1 = land1.get(i).y;
+			for(int j = 0; j < land2.size(); j++) {
+				int x2 = land2.get(j).x;
+				int y2 = land2.get(j).y;
+				if(x1 != x2 && y1 != y2) continue;
+				int ret = 1;
+				if(x1 == x2) {
+					if(y1 > y2) {
+						boolean flag = true;;
+						for(int k = y2 + 1; k < y1; k++) {
+							if(arr[x1][k] == 1) {
+								flag = false;
+								break;
+							}
+						}
+						if(flag) ret = y1 - y2 - 1;
+					}
+					else {
+						boolean flag = true;;
+						for(int k = y1 + 1; k < y2; k++) {
+							if(arr[x1][k] == 1) {
+								flag = false;
+								break;
+							}
+						}
+						if(flag) ret = y2 - y1 - 1;
+					}
+				}
+				else if(y1 == y2) {
+					if (x1 > x2) {
+						boolean flag = true;;
+						for(int k = x2 + 1; k < x1; k++) {
+							if(arr[k][y1] == 1) {
+								flag = false;
+								break;
+							}
+						}
+						if(flag) ret = x1 - x2 - 1;
+					}
+					else {
+						boolean flag = true;;
+						for(int k = x1 + 1; k < x2; k++) {
+							if(arr[k][y1] == 1) {
+								flag = false;
+								break;
+							}
+						}
+						if(flag) ret = x2 - x1 - 1;
+					}
+				}
+				if(ret < 2) continue;
+				cnt = Math.min(ret, cnt);
+			}
+		}
+		if(cnt != Integer.MAX_VALUE) route.offer(new Route(idx1 + 1,idx2 + 1,cnt));
+	}
+	public static void makeRoute() {
+		for(int i = 0; i < landSize; i++) {
+			for(int j = i + 1; j < landSize; j++) {
+				findRoute(i,j);
+			}
+		}
+	}
+	
+	public static void solution() {
+		init();
+		addLand();
+		makeRoute();
+		int ans = 0;
+		while(!route.isEmpty()) {
+			Route r = route.peek();
+			route.remove();
+			int s = r.size;
+			int idx1 = r.idx1;
+			int idx2 = r.idx2;
+
+			if(findParent(idx1) == findParent(idx2)) continue;
+			unionParent(idx1, idx2);
+			ans += s;
+			if(isAllUnion()) {
+				System.out.println(ans);
+				return;
+			}
+			
+		}
+		System.out.println(-1);
+	}
+	public static int makeArray(int[] arr) {
+		int sum = 0;
+		for(int i : arr) {
+			sum += i;
+		}
+		return sum;
+	}
+	public static void main(String[] args) {
+		solution();
+	}
+}

--- a/김동하/1주차/[Baekjoon-2578] 빙고.java
+++ b/김동하/1주차/[Baekjoon-2578] 빙고.java
@@ -1,0 +1,94 @@
+package baekjoon;
+
+import java.util.Scanner;
+
+public class Main {
+	public static Scanner scanner = new Scanner(System.in);
+	public static int arr[][] = new int[6][6];
+	public static int cnt = 0;
+	
+	public static boolean leftDown = false;
+	public static boolean rightDown = false;
+	
+	public static boolean isEnd = false;
+	
+	public static void init() {
+		for(int i = 1; i <= 5; i++) {
+			for(int j = 1; j <= 5; j++) {
+				arr[i][j] = scanner.nextInt();
+			}
+		}
+	}
+	public static class Node{
+		int x,y;
+		public Node(int x,int y) {
+			this.x = x;
+			this.y = y;
+		}
+	}
+	
+	public static Node deleteBingo(int x) {
+		for(int i = 1; i <= 5; i++) {
+			for(int j = 1; j <= 5; j++) {
+				if(arr[i][j] == x) {
+					arr[i][j] = 0;
+					return new Node(i,j);
+				}
+			}
+		}
+		return new Node(1,1);
+	}
+	
+	public static void countLD() {
+		for(int i = 5; i > 0; i--) {
+			if(arr[6 - i][i] != 0) return;
+		}
+		cnt++;
+		leftDown = true;
+	}
+	
+	public static void countRD() {
+		for(int i = 1; i <= 5; i++) {
+			if(arr[i][i] != 0) return;
+		}
+		cnt++;
+		rightDown = true;
+	}
+	
+	public static void checkBingo(int x, int y) {
+		boolean succ = true;
+		for(int i = 1; i <= 5; i++) {
+			if(arr[x][i] != 0) {
+				succ = false;
+				break;
+			}
+		}
+		if(succ) cnt++;
+		succ = true;
+		for(int i = 1; i <= 5; i++) {
+			if(arr[i][y] != 0) {
+				succ = false;
+				break;
+			}
+		}
+		if(!leftDown) countLD();
+		if(!rightDown) countRD();
+		if(succ) cnt++;
+	}
+	public static void solution() {
+		init();
+		for(int i = 0; i < 25; i++) {
+			int x = scanner.nextInt();
+			Node node = deleteBingo(x);
+			checkBingo(node.x, node.y);
+			if(!isEnd && cnt >= 3) {
+				isEnd = true;
+				System.out.println(i + 1);
+			}
+		}
+	}
+	
+	public static void main(String[] args) {
+		solution();
+	}
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 1주차 [김동하] 

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **문제 1**
  - [x] **문제 2**  
  - [x] **문제 3**
  - [x] **문제 4**  
  - [x] **문제 5**  

---

## 💡 풀이 방법
### 문제 1: 다리만들기 2

**문제 난이도**
골드 1


**문제 유형**
bfs, mst


 **접근 방식 및 풀이**

- ### 문제를 풀 때 든 생각
처음엔 각 섬마다 최소 x , 최대x, 최소 y, 최대 y 를 저장해두고 섬끼리 비교할 때 그 섬들의 최소 최대값들로 비교하는 방식으로 구현했었다 -> 섬이 직사각형이 보장이 안됨
결국 섬에 해당하는 좌표값들을 전부 각 섬 별로 저장하고 하나하나 비교하는 완탐을 했다
- ### 구상
  1. 각 섬을 나눠주고 섬에대한 정보들을 저장해야함
  2. 각 섬 사이에 다리를 세울 때 다리의 최솟값을 구해줘야함
  3. 다리가 세워진 섬을 연결해줘야함
- 1번 로직
  - 각 좌표를 돌며 방문을 안한 좌표라면 bfs를 돌려서 인접한 땅을 하나의 섬으로 추가해줌
- 2번 로직
  - 구하려는 두 섬 사이의 좌표를 완전 탐색하여 최소값을 저장함
- 3번 로직
  - mst (Union-Find) 알고리즘을 활용
  -  다리들을 길이가 최소인 값으로 정렬해둔 뒤 최소인 다리부터 추가하며 섬들을 연결
  - 모든 다리가 연결되었으면 즉시 종료
   
---



### 문제 2: 빙고

**문제 난이도**
실버 4

 **문제 유형**
구현


 **접근 방식 및 풀이**

- ### 문제를 풀 때 든 생각
처음 문제를 보고는 생각보다 난해하다는 생각이 들어서 입력의 크기를 살펴봤다.
입력의 크기가 5*5 크기로 고정이 되어있는 것을 보고 완전탐색으로 풀어도 시간이 크게 걸리지 않는다는 생각을 하고 바로 완전탐색으로 구현에 들어갔다.

- ### 구상
- 5*5 사이즈의 배열을 입력받아 채움
- 전체 배열을 순회하며 값을 찾아 입력받은 값을 삭제하는 deleteNode 메서드로 입력 받을 때 마다 지워줌
- 방금 입력한 값에 의해서 새롭게 생성된 빙고줄이 있는지 체크함
- 위 과정을 반복하여 빙고가 3줄이상이 되었다면 즉시 종료함


---
### 문제 3: 문제 이름 

**문제 난이도**
실버 1

 **문제 유형**
DP


 **접근 방식 및 풀이**

- ### 문제를 풀 때 든 생각
보자마자 DP문제라는 생각이 들었다.
DP문제라는 생각을 하고 나서는 바로 규칙, 점화식 찾기에 몰두했다.

- ### 구상
이전 단계에서 추가되는 경우가 뭐가 있을지를 생각해 보았다
  - 1. 끝이 0으로 끝나는 경우
  - 2. 끝이 9로 끝나는 경우
  - 3. 나머지 숫자로 끝나는 경우
  - 1번과 2번 같은 경우에는 각각 1 과 8을 추가하는 방법 밖에 없기에 이전 경우 그대로 간다.
  - 나머지 경우에는 각각 두가지 경우가 있으므로 이전 경우의수 * 2 가 각각의 자리수 DP배열로 들어간다.

따라서, 나온 점화식은 다음과 같다
```  java
		for(int i = 2; i <= n; i++) {
			for(int j = 0; j < 10; j++) {
				if(j == 0) dp[i][j] = dp[i - 1][j + 1];
				else if(j == 9) dp[i][j] = dp[i - 1][j - 1];
				else dp[i][j] = (dp[i - 1][j -1] + dp[i - 1][j + 1]) % 1000000000;
			}
		}
```

---

### 문제 4: 게리맨더링

**문제 난이도**
골드 3

 **문제 유형**
bfs


 **접근 방식 및 풀이**

- ### 문제를 풀 때 든 생각
처음 문제를 봤을 때는 bfs를 써야한다고 생각은 들었지만 어떻게 나눠줘야 할지가 고민이었다.
그런데 입력 사이즈를 보니 배열로 체크해가며 완전탐색을 돌려도 괜찮겠다 라는 생각이 들었다.

- ### 구상
선거구를 나눠주는 devide 메서드를 사용
이 메서드는 재귀메서드로 idx가 n이 될때까지 순차적으로 isContain 배열에 체크를 한다.
이후 idx가 n에 도달하면 체크되어있는 idx 는 list1에, 안되어있는 idx는 list2에 나눠 담는다.
빈 배열이 있다면 바로 반환하고, 배열에 들어있는 노드들을 bfs로 돌리며 모두 연결이 되었는지를 체크해준다.
list1과 list2가 각각 모두 연결 되어있다면 두 list 각각의 합의 차를 구한다.

이를 모든 경우의수가 다 되도록 완전 탐색을 돌린다.

---
### 문제 5: 문제 이름 

**문제 난이도**
골드 5

 **문제 유형**
완전탐색


 **접근 방식 및 풀이**

- ### 문제를 풀 때 든 생각
이문제는 처음 봤을 때 이해가 잘 가지않아서 많이 돌려 읽었던 문제다.
이해를 하고보니 생각보다 단순한 문제였고 두가지만 주의하면 되는 문제였다.
입출력 사이즈도 작아서 단순히 bfs변형만 시키면 되는 문제다.


- ### 구상
bfs를 돌리듯 dx,dy값을 설정하는데 방향은 우측, 하단, 오른쪽 대각선 아래 이렇게 세 개로 설정했다.
이때 주의할 점은 가로일때는 우측, 대각선으로 밖에 못가고 세로일때는 하단, 대각선 이렇게 밖에 가지 못해서 체크해 주어야 한다는 점이다.
따라서 재귀메소드로 만들며 파라미터로 현재 방향을 넘겨주어 dx,dy할때의 인덱스 값과 비교해주어 방향을 판별했다.
또하나 주의할점은 가로, 세로 일때는 도착지점만 벽이 없으면 되기에 넘어가도 되지만 대각선일 때는 도착지점의 한칸위, 한칸 왼쪽 까지 벽이 없어야 하므로 그점만 체크해 주면 쉽게 풀리는 문제였다.
