### PR TITLE
[박예진-10주차 알고리즘 스터디]

### DIFF
--- a/박예진/10주차/[백준 10815] 숫자 카드.cpp
+++ b/박예진/10주차/[백준 10815] 숫자 카드.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+using namespace std;
+
+/*
+	숫자 카드를 상근이가 가지고 있는지 아닌지
+	N ~ 50만
+*/
+
+int N, M; // 숫자카드 개수
+int card[500001];
+
+bool binary_search(int num) {
+	int left = 0;
+	int right = N - 1;
+
+	while (left <= right) {
+		int mid = (left + right) / 2;
+
+		if (card[mid] == num) return true;
+    
+		if (card[mid] < num) left = mid + 1;
+		else right = mid - 1;
+	}
+	return false;
+}
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL); cout.tie(NULL);
+
+	cin >> N;
+	for (int i = 0; i < N; i++) {
+		cin >> card[i];
+	}
+	sort(card, card + N);
+
+	cin >> M;
+	while (M-- > 0) {
+		int num;
+		cin >> num;
+		bool flag = binary_search(num);
+		cout << (flag ? 1 : 0) << " ";
+	}
+
+	return 0;
+}

--- a/박예진/10주차/[백준 11000] 강의실.cpp
+++ b/박예진/10주차/[백준 11000] 강의실.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <queue>
+using namespace std;
+
+/*
+	최소의 강의실을 사용해 모든 수업 가능하도록
+*/
+
+struct Lecture {
+	int start, end;
+
+	bool operator() (Lecture l1, Lecture l2) {
+		return l1.start < l2.start;
+	}
+};
+
+int N;
+vector<Lecture> lectures;
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL); cout.tie(NULL);
+
+	cin >> N;
+	lectures.resize(N);
+	for (int i = 0; i < N; i++) {
+		cin >> lectures[i].start >> lectures[i].end;
+	}
+
+	sort(lectures.begin(), lectures.end(), Lecture());
+
+	priority_queue<int, vector<int>, greater<int>> pq; // 강의실 개수
+	pq.push(lectures[0].end);
+
+	for (int i = 1; i < N; i++) {
+		if (lectures[i].start >= pq.top()) pq.pop();
+		pq.push(lectures[i].end);
+	}
+
+	cout << pq.size();
+
+	return 0;
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 10주차 [박예진] 

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [ ] **문제 1 : 마법사 상어와 블리자드**
  - [x] **문제 2 : 숫자 카드**  
  - [ ] **문제 3 : 두 배열의 합**
  - [ ] **문제 4 : 종이 조각**  
  - [x] **문제 5 : 강의실 배정**  
---

## 💡 풀이 방법
### 문제 1: 마법사 상어와 블리자드 

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**

   
---



### 문제 2: 숫자 카드
**문제 난이도**
실버5

 **문제 유형**
이분탐색


 **접근 방식 및 풀이**
정렬 후에, 이분탐색으로 배열에 값이 있는지 확인하는 문제이다. 
카드 개수가 최대 50만이고, 확인하는 횟수도 50만이라 값이 매우 크기 때문에
이분탐색을 활용해 효율적으로 검사해야한다.


---
### 문제 3: 두 배열의 합

**문제 난이도**

 **문제 유형**



 **접근 방식 및 풀이**



---
### 문제 4: 종이 조각
**문제 난이도**


 **문제 유형**



 **접근 방식 및 풀이**


---
### 문제 5: 강의실 배정

**문제 난이도**
골드5

 **문제 유형**
우선순위큐

 **접근 방식 및 풀이**
단순히 문제 제목만 보고 그리디로 풀었었다.
그러나, 이번 문제는 최소의 강의실을 사용해 모든 수업이 가능하도록 하는 **강의실 개수**를 구하는 문제였다.
따라서, 우선순위큐를 사용하였다.

강의 끝나는 시간을 넣어서 
다음 시작시간이 현재 끝나는 시간보다 크거나 같으면, 현재 강의실 사용 가능하니까 pq.pop을 해주고 값을 넣어주고
다음 시작시간이 현재 끝나는 시간보다 작다면, 현재 강의실이 사용 불가하니까 값을 넣어준다.

마지막으론 pq 사이즈를 출력해주면 된다.