### PR TITLE
[문한결-10주차 알고리즘 스터디]

### DIFF
--- a/문한결/10주차/강의실.java
+++ b/문한결/10주차/강의실.java
@@ -1,0 +1,53 @@
+package solution;
+
+import java.util.*;
+import java.io.*;
+
+
+
+public class 강의실 {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static int n;
+    static int[] input;
+    static int arr[][];
+    static int answer=0;
+    static Queue<Integer> priorQue;
+
+
+
+    public static void main(String[] args) throws IOException {
+        init();
+        execute();
+        System.out.println(answer);
+
+
+    }
+
+    static void init() throws IOException {
+    	n=Integer.parseInt(br.readLine());
+    	arr=new int[n][2];
+        for(int i=0;i<n;i++) {
+        input = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+        arr[i][0]=input[0];
+        arr[i][1]=input[1];
+        }
+        Arrays.sort(arr,Comparator.comparingInt(arr1->arr1[0]));
+        priorQue=new PriorityQueue();
+     
+    }
+    
+    static void execute() {
+    for(int i=0;i<n;i++) {
+    	if(priorQue.peek()==null || priorQue.peek()>arr[i][0]) answer++;
+    	else priorQue.remove();
+    	
+    
+    	priorQue.add(arr[i][1]);
+    }
+    }
+}
+
+
+
+

--- a/문한결/10주차/배열합.java
+++ b/문한결/10주차/배열합.java
@@ -1,0 +1,65 @@
+package solution;
+
+import java.util.*;
+import java.io.*;
+
+public class 배열합 {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    static long t;
+    static int n, m;
+    static long[] a, b;
+    static Map<Long, Long> aMaps;
+    static Map<Long, Long> bMaps;
+    static long answer = 0;
+    static long[][] arr;
+    static long[][] brr;
+
+    public static void main(String[] args) throws Exception {
+        init();
+        execute();
+        System.out.println(answer);
+    }
+
+    static void init() throws Exception {
+        t = Long.parseLong(br.readLine());
+        n = Integer.parseInt(br.readLine());
+        aMaps = new HashMap<>();
+        bMaps = new HashMap<>();
+        arr = new long[n][n];
+        a = Arrays.stream(br.readLine().split(" ")).mapToLong(Long::parseLong).toArray();
+        for (int i = 0; i < n; i++) {
+            arr[0][i] = a[i];
+            aMaps.put(a[i], aMaps.getOrDefault(a[i], 0L) + 1);
+        }
+        m = Integer.parseInt(br.readLine());
+        b = Arrays.stream(br.readLine().split(" ")).mapToLong(Long::parseLong).toArray();
+        brr = new long[m][m];
+        for (int i = 0; i < m; i++) {
+            brr[0][i] = b[i];
+            bMaps.put(b[i], bMaps.getOrDefault(b[i], 0L) + 1);
+        }
+    }
+
+    static void execute() {
+        for (int i = 1; i < n; i++) {
+            for (int j = i; j < n; j++) {
+                arr[i][j] = a[j] + arr[i - 1][j - 1];
+                aMaps.put(arr[i][j], aMaps.getOrDefault(arr[i][j], 0L) + 1);
+            }
+        }
+        for (int i = 1; i < m; i++) {
+            for (int j = i; j < m; j++) {
+                brr[i][j] = b[j] + brr[i - 1][j - 1];
+                bMaps.put(brr[i][j], bMaps.getOrDefault(brr[i][j], 0L) + 1);
+            }
+        }
+
+        for (long i : aMaps.keySet()) {
+            long num = aMaps.get(i);
+            answer += bMaps.getOrDefault(t - i, 0L) * num;
+        }
+    }
+}
+

--- a/문한결/10주차/블리자드.java
+++ b/문한결/10주차/블리자드.java
@@ -1,0 +1,219 @@
+package solution;
+import java.util.*;
+import java.io.*;
+
+
+public class 블리자드  {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static int n, m;
+    static int[][] blizard, maps;
+    static int[] input;
+    static int[] dx = {-1, 0, 1, 0}, dy = {0, 1, 0, -1};
+    static int startX;
+    static int startY;
+    static List<Integer> list;
+    static List<Group> groups;
+    static int answer[] = new int[4];
+
+
+
+    public static void main(String[] args) throws IOException {
+        init();
+        execute();
+        System.out.println(answer[1]+2*answer[2]+3*answer[3]);
+
+
+    }
+
+    static void init() throws IOException {
+        input = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+        n = input[0];
+        m = input[1];
+        maps = new int[n][n];
+        blizard = new int[m][2];
+        for (int i = 0; i < n; i++) {
+            input = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+            for (int j = 0; j < n; j++)
+                maps[i][j] = input[j];
+        }
+        for (int i = 0; i < m; i++) {
+            input = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+            blizard[i][0] = input[0];
+            blizard[i][1] = input[1];
+        }
+        startX = startY = (n + 1) / 2 - 1;
+    }
+
+    static void execute() {
+        for (int i = 0; i < m; i++) {
+            int d = convertDir(blizard[i][0]);
+            int s = blizard[i][1];
+            goBlizard(d, s);
+            moveBall();
+         
+            explode();
+      
+            insertBall();
+        }
+    }
+
+    static int convertDir(int d) {
+        switch (d) {
+            case 1:
+                return 3;
+            case 2:
+                return 1;
+            case 3:
+                return 0;
+            case 4:
+                return 2;
+        }
+        return 0;
+    }
+
+    static void goBlizard(int d, int s) {
+        for (int i = 1; i < s + 1; i++) {
+            if (startX + i * dx[d] >= 0 && startX + i * dx[d] < n && startY + i * dy[d] >= 0
+                    && startY + i * dy[d] < n)
+                maps[startY + i * dy[d]][startX + i * dx[d]] = 0;
+        }
+    }
+
+    static void moveBall() {
+        list = new ArrayList<>();
+        int curX = startX;
+        int curY = startY;
+        int cnt = 0;
+        int dir = 0;
+        int conti = 0;
+        int convertNum = 1;
+        int ccc = 0;
+        while (cnt < n * n - 1) {
+            curX += dx[dir];
+            curY += dy[dir];
+            if (maps[curY][curX] != 0)
+                list.add(maps[curY][curX]);
+            conti += 1;
+            cnt++;
+            if (conti == convertNum) {
+                dir = (dir + 1) % 4;
+                conti = 0;
+                ccc += 1;
+            }
+            if (ccc == 2) {
+                ccc = 0;
+                convertNum++;
+            }
+
+        }
+    }
+
+    static void explode() {
+        groups = new ArrayList<>();
+       
+        for (int i : list) {
+            if (groups.size() > 0 && groups.get(groups.size() - 1).value == i) {
+                groups.get(groups.size() - 1).n++;
+            } else {
+                groups.add(new Group(i, 1));
+            }
+        }
+     
+        List<Group> temps = new ArrayList<>();
+        for (Group g : groups)
+            temps.add(g);
+        
+        int cnt = 0;
+        
+        for (int i = 0; i < groups.size(); i++) {
+            if (groups.get(i).n >= 4) {
+                answer[groups.get(i).value] += groups.get(i).n;
+                temps.remove(i - cnt);
+                cnt++;
+            }
+        }
+        
+        groups = temps;
+   
+        boolean isFinish = false;
+        while (!isFinish) {
+            isFinish = true;
+            List<Group> lists = new ArrayList<>();
+            for (Group g : groups) {
+                if (lists.size() > 0 && lists.get(lists.size() - 1).value == g.value) {
+                    lists.get(lists.size() - 1).n += g.n;
+                } else {
+                    lists.add(new Group(g.value, g.n));
+                }
+            }
+
+            temps = new ArrayList<>();
+            for (Group g : lists)
+                temps.add(new Group(g.value,g.n));
+           
+            cnt = 0;
+            for (int i = 0; i < lists.size(); i++) {
+                if (lists.get(i).n >= 4) {
+                    temps.remove(i - cnt);
+                    cnt++;
+                    answer[lists.get(i).value] += lists.get(i).n;
+                    isFinish = false;
+                }
+            }
+            groups = temps;
+        }
+      
+
+
+    }
+
+    static void insertBall() {
+        int curX = startX;
+        int curY = startY;
+        int cnt = 0;
+        int dir = 0;
+        int conti = 0;
+        int convertNum = 1;
+        int ccc = 0;
+        maps=new int[n][n];
+        while (cnt < n * n - 1) {
+            curX += dx[dir];
+            curY += dy[dir];
+            if(cnt/2>=groups.size())break;
+            if (cnt % 2 == 0)
+                maps[curY][curX] = groups.get(cnt/2).n;
+            else
+                maps[curY][curX] = groups.get(cnt/2).value;
+            conti += 1;
+            cnt++;
+            if (conti == convertNum) {
+                dir = (dir + 1) % 4;
+                conti = 0;
+                ccc += 1;
+            }
+            if (ccc == 2) {
+                ccc = 0;
+                convertNum++;
+            }
+
+        }
+        
+    }
+
+
+}
+
+
+class Group {
+    int n;
+    int value;
+
+    public Group(int v, int n) {
+        this.n = n;
+        this.value = v;
+    }
+
+}
+
+

--- a/문한결/10주차/숫자카드.java
+++ b/문한결/10주차/숫자카드.java
@@ -1,0 +1,37 @@
+package solution;
+
+import java.util.*;
+import java.io.*;
+
+public class 숫자카드  {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+
+    static int n, m;
+    static int[] cards, validatedCards;
+    static Set<Integer> sets;
+
+    public static void main(String[] args) throws Exception {
+        init();
+        findAnswer();
+    }
+
+    static void init() throws Exception {
+        n = Integer.parseInt(br.readLine());
+        sets = new HashSet<>();
+        cards = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+        for (int i : cards)
+            sets.add(i);
+        m = Integer.parseInt(br.readLine());
+        validatedCards =
+                Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+
+    }
+
+    static void findAnswer() {
+        for (int i : validatedCards) {
+            System.out.print(sets.contains(i) ? 1 + " " : 0 + " ");
+        }
+    }
+}

--- a/문한결/10주차/종이조각.java
+++ b/문한결/10주차/종이조각.java
@@ -1,0 +1,77 @@
+package solution;
+import java.util.*;
+import java.io.*;
+
+
+
+// 각 칸은 가로아니면 세로에 포함됨
+// 가로: 1 세로:0 전체 경우의 수: 1<<(n*m)
+public class 종이조각{
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static int n, m;
+    static int[] input;
+    static int arr[][];
+    static int answer=0;
+    static int sum=0;
+    static String temp="";
+
+    public static void main(String[] args) throws IOException {
+        init();
+        execute();
+        System.out.println(answer);
+
+
+    }
+
+    static void init() throws IOException {
+        input = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+        n=input[0];
+        m=input[1];
+        arr=new int[n][m];
+        for(int i=0;i<n;i++) {
+            input = Arrays.stream(br.readLine().split("")).mapToInt(Integer::parseInt).toArray();
+            for(int j=0;j<m;j++)arr[i][j]=input[j];
+        }
+    }
+    
+    static void execute() {
+    	for(int i=0;i<(1<<(n*m));i++) {
+    		sum=0;
+    		temp="";
+    		for(int j=0;j<n;j++) {
+        		temp="";
+    			for(int k=0;k<m;k++) {
+    				int pos=k+j*m;
+    				if(((1<<pos)&i)>0) {
+    					temp=temp+String.valueOf(arr[j][k]);
+    				}else {
+    					if(!temp.equals(""))sum+=Integer.valueOf(temp);
+    					temp="";
+    				}
+    			}
+				if(!temp.equals(""))sum+=Integer.valueOf(temp);
+
+    		}
+    		for(int j=0;j<m;j++) {
+        		temp="";
+    			for(int k=0;k<n;k++) {
+    				int pos=k*m+j;
+    				if(((1<<pos)&i)==0) {
+    					temp=temp+String.valueOf(arr[k][j]);
+    				}else {
+    					if(!temp.equals(""))sum+=Integer.valueOf(temp);
+    					temp="";
+    				}
+    			}
+				if(!temp.equals(""))sum+=Integer.valueOf(temp);
+
+    		}
+    		answer=Math.max(answer, sum);
+    		
+    	}
+    }
+}
+
+
+


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 10주차 [문한결]

## 📌 문제 풀이 개요

- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.

---

## ✅ 문제 해결 여부

- [x] **문제 1: 마법사 상어와 블리자드**
- [x] **문제 2: 숫자 카드**
- [x] **문제 3: 두 배열의 합**
- [x] **문제 4: 종이 조각**
- [x] **문제 5: 강의실 배정**

---

## 💡 풀이 방법

### 문제 1: 마법사 상어와 블리자드

**문제 난이도**
Gold 1

**문제 유형**
```구현```

## **접근 방식 및 풀이**
진짜 어떠한 스킬도 들어가지 않은 구현 그자체인 문제이다.
이런 문제에서는 메서드의 설계와 각 메서드를 얼만큼 정확하게 구현하냐고 포인트라고 생각한다.

실행하는 ```execute```메서드 내에서는 아래의 메서드가 순서대로 동작한다.

```goBlizard```:  블리자드를 사용시 구슬을 없앤다.
```moveBall```:  구슬이 있던 자리를 매꾸기 위해서 구슬을 움직인다.
```explode```:   같은 구슬이 4개있을 시 폭발하는 구현.
```insertBall```:  마지막으로 구슬의 그룹이 몇개 인지, 몇번 구슬인지를 통해서 map에 구슬을 넣는다.




---

### 문제 2: 숫자 카드

**문제 난이도**
Silver 5

**문제 유형**
```이분 탐색```

## **접근 방식 및 풀이**
이분 탐색 유형이긴 하지만, 그냥 ```Set```을 쓰면 편하게 풀 수 있을 것 같아서 ```Set```으로 풀었다. 


---

### 문제 3: 두 배열의 합

**문제 난이도**
Gold 3

**문제 유형**
```이분 탐색```

## **접근 방식 및 풀이**
이 문제는 a,b에서 각각 나올 수 있는 배열의 합을 키로 하고 합의 갯수를 value로 하는 Map을 정의하고 넣는다.
후에 아래처럼 Map에서 꺼내서, 합이 t가 될 때의 b합의 갯수를 꺼내고, aMap에서 i의 갯수를 곱하고 답에 더하면 된다. 
```java
       for (long i : aMaps.keySet()) {
            long num = aMaps.get(i);
            answer += bMaps.getOrDefault(t - i, 0L) * num;
        }
```

---

### 문제 4: 종이 조각

**문제 난이도**
Gold 3

**문제 유형**
```비트마스킹```

## **접근 방식 및 풀이**
각 자리는 가로 or 세로로 정해진다. 이점에 착안해서 가로를 1로, 세로일 때는 0으로 정의해서 총 
1<<(n*m)의 갯수를 돌면서 모든 경우의 수일 때, 배열을 돌면서 수들의 합을 구하면된다. 


---

### 문제 5: 강의실 배정

**문제 난이도**
Gold 5

**문제 유형**
```그리디```

## **접근 방식 및 풀이**
뭔가 어디선가 풀어본 느낌의 문제.
우선순위 큐에 끝나는 시간을 언제 뺄지를 아는게 포인트라고 생각한다.


---
