### PR TITLE
[김민진-10주차 알고리즘 스터디]

### DIFF
--- a/김민진/10주차/[Baekjoon-10815] 숫자 카드.java
+++ b/김민진/10주차/[Baekjoon-10815] 숫자 카드.java
@@ -1,0 +1,51 @@
+package week10;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Q2NumberCard {
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static StringBuilder sb = new StringBuilder();
+    private static StringTokenizer st;
+    
+    private static final int MAX_NUM = 10_000_000;
+    private static final int OFFSET = MAX_NUM;
+
+    private static int N;
+    private static int M;
+
+    private static boolean[] cards;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+
+        cards = new boolean[2 * MAX_NUM + 1];
+        for (int i = 0; i < N; i++) {
+        	int idx = Integer.parseInt(st.nextToken());
+        	
+        	cards[idx + OFFSET] = true;
+        }
+    }
+
+    private static void sol() throws IOException {
+        M = Integer.parseInt(br.readLine());
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < M; i++) {
+            int target = Integer.parseInt(st.nextToken());
+
+            sb.append(cards[target + OFFSET] ? "1 " : "0 ");
+        }
+        System.out.println(sb);
+    }
+
+}

--- a/김민진/10주차/[Baekjoon-11000] 강의실 배정.java
+++ b/김민진/10주차/[Baekjoon-11000] 강의실 배정.java
@@ -1,0 +1,84 @@
+package week10;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Q5AssigningClassroom {
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static StringTokenizer st;
+
+    private static int N;
+    private static int cnt;
+
+    private static Classroom[] classes;
+
+    private static Queue<Integer> q;
+
+    private static class Classroom implements Comparable<Classroom> {
+
+        int start;
+        int end;
+
+        public Classroom(int start, int end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        @Override
+        public int compareTo(Classroom o) {
+            int comp = Integer.compare(this.start, o.start);
+
+            if (comp == 0) {
+                return Integer.compare(this.end, o.end);
+            }
+
+            return comp;
+        }
+
+    }
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static int nextInt() {
+        return Integer.parseInt(st.nextToken());
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        cnt = 0;
+
+        classes = new Classroom[N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            classes[i] = new Classroom(nextInt(), nextInt());
+        }
+        Arrays.sort(classes);
+
+        q = new PriorityQueue<>();
+    }
+
+    private static void sol() {
+        q.offer(classes[0].end);
+
+        for (int i = 1; i < N; i++) {
+
+            if (q.peek() <= classes[i].start) {
+                q.poll();
+            }
+
+            q.offer(classes[i].end);
+        }
+        System.out.println(q.size());
+    }
+
+}

--- a/김민진/10주차/[Baekjoon-14391] 종이 조각.java
+++ b/김민진/10주차/[Baekjoon-14391] 종이 조각.java
@@ -1,0 +1,105 @@
+package week10;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Q4PieceOfPaper {
+
+    private static final int HOR = 0;
+    private static final int VER = 1;
+
+    private static final int[] dx = {0, 1};
+    private static final int[] dy = {1, 0};
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static StringTokenizer st;
+
+    private static int N;
+    private static int M;
+    private static int max;
+
+    private static int[][] nums;
+    private static boolean[][] pieces;
+    private static boolean[][] visited;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol(0, 0);
+        
+        System.out.println(max);
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        max = 0;
+
+        nums = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            String s = br.readLine();
+            for (int j = 0; j < M; j++) {
+                nums[i][j] = Integer.parseInt(s.charAt(j) + "");
+            }
+        }
+        pieces = new boolean[N][M];
+        visited = new boolean[N][M];
+    }
+
+    private static void sol(int i, int j) {
+        if (i == N) {
+            max = Math.max(max, totalSum());
+            visited = new boolean[N][M];
+            return;
+        }
+
+        if (j == M) {
+            sol(i + 1, 0);
+            return;
+        }
+
+        // horizontal
+        pieces[i][j] = true;
+        sol(i, j + 1);
+
+        // vertical
+        pieces[i][j] = false;
+        sol(i, j + 1);
+    }
+
+    private static int totalSum() {
+        int res = 0;
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (visited[i][j]) {
+                    continue;
+                }
+                res += partialSum(i, j, pieces[i][j] ? HOR : VER);
+            }
+        }
+        return res;
+    }
+
+    private static int partialSum(int i, int j, int dir) {
+        int res = 0;
+
+        int ni = i;
+        int nj = j;
+
+        while (ni < N && nj < M && !visited[ni][nj] && 
+              (pieces[ni][nj] ? HOR : VER) == dir) {
+        	
+            res = res * 10 + nums[ni][nj];
+            visited[ni][nj] = true;
+            
+            ni += dx[dir];
+            nj += dy[dir];
+        }
+        return res;
+    }
+
+}

--- a/김민진/10주차/[Baekjoon-2143] 두 배열의 합.java
+++ b/김민진/10주차/[Baekjoon-2143] 두 배열의 합.java
@@ -1,0 +1,51 @@
+package week10;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Q3SumOfTwoArrays {
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static StringBuilder sb = new StringBuilder();
+    private static StringTokenizer st;
+
+    private static final int MAX_NUM = 10_000_000;
+    private static final int OFFSET = MAX_NUM;
+
+    private static int N;
+    private static int M;
+
+    private static boolean[] cards;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+
+        cards = new boolean[2 * MAX_NUM + 1];
+        for (int i = 0; i < N; i++) {
+            int idx = Integer.parseInt(st.nextToken());
+
+            cards[idx + OFFSET] = true;
+        }
+    }
+
+    private static void sol() throws IOException {
+        M = Integer.parseInt(br.readLine());
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < M; i++) {
+            int target = Integer.parseInt(st.nextToken());
+
+            sb.append(cards[target + OFFSET] ? "1 " : "0 ");
+        }
+        System.out.println(sb);
+    }
+
+}

--- a/김민진/10주차/[Baekjoon-2143] 두 배열의 합.java
+++ b/김민진/10주차/[Baekjoon-2143] 두 배열의 합.java
@@ -3,21 +3,24 @@ package week10;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.StringTokenizer;
 
 public class Q3SumOfTwoArrays {
 
     private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-    private static StringBuilder sb = new StringBuilder();
     private static StringTokenizer st;
 
-    private static final int MAX_NUM = 10_000_000;
-    private static final int OFFSET = MAX_NUM;
-
+    private static int T;
     private static int N;
     private static int M;
+    private static long cnt;
 
-    private static boolean[] cards;
+    private static long[] A;
+    private static long[] B;
+
+    private static Map<Long, Integer> map;
 
     public static void main(String[] args) throws IOException {
         init();
@@ -25,27 +28,52 @@ public class Q3SumOfTwoArrays {
     }
 
     private static void init() throws IOException {
+        T = Integer.parseInt(br.readLine());
+        cnt = 0;
+
         N = Integer.parseInt(br.readLine());
+
+        A = new long[N + 1];
         st = new StringTokenizer(br.readLine());
-
-        cards = new boolean[2 * MAX_NUM + 1];
-        for (int i = 0; i < N; i++) {
-            int idx = Integer.parseInt(st.nextToken());
-
-            cards[idx + OFFSET] = true;
+        for (int i = 1; i <= N; i++) {
+            A[i] = A[i - 1] + Long.parseLong(st.nextToken());
         }
-    }
 
-    private static void sol() throws IOException {
         M = Integer.parseInt(br.readLine());
 
+        B = new long[M + 1];
         st = new StringTokenizer(br.readLine());
-        for (int i = 0; i < M; i++) {
-            int target = Integer.parseInt(st.nextToken());
-
-            sb.append(cards[target + OFFSET] ? "1 " : "0 ");
+        for (int i = 1; i <= M; i++) {
+            B[i] = B[i - 1] + Long.parseLong(st.nextToken());
         }
-        System.out.println(sb);
+
+        map = new HashMap<>();
+    }
+
+    private static void sol() {
+        // put the sums of subarrays to map
+        for (int i = 1; i <= N; i++) {
+            for (int j = i; j <= N; j++) {
+                long tmpA = getPartialSum(i, j, A);
+
+                map.put(tmpA, map.getOrDefault(tmpA, 0) + 1);
+            }
+        }
+
+        // compare with the sum of subarrays of b
+        for (int i = 1; i <= M; i++) {
+            for (int j = i; j <= M; j++) {
+                long tmpB = getPartialSum(i, j, B);
+
+                cnt += map.getOrDefault(T - tmpB, 0);
+            }
+        }
+
+        System.out.println(cnt);
+    }
+
+    private static long getPartialSum(int i, int j, long[] mat) {
+        return mat[j] - mat[i - 1];
     }
 
 }

--- a/김민진/10주차/[Baekjoon-21611] 마법사 상어와 블리자드.java
+++ b/김민진/10주차/[Baekjoon-21611] 마법사 상어와 블리자드.java
@@ -1,0 +1,221 @@
+package week10;
+
+import java.awt.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Q1WizardSharkAndBlizzard {
+
+    private static final int[] dx = {0, -1, 1, 0, 0};
+    private static final int[] dy = {0, 0, 0, -1, 1};
+
+    private static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static StringTokenizer st;
+
+    private static int N;
+    private static int M;
+    private static int D; // dir of magic
+    private static int S; // dist of magic
+
+    private static int[] cnt;       // 터진 구슬 개수 저장
+    private static Point[] linearIdx; // 상어를 시작(0)으로 N*N-1까지 달팽이 형태로 맵 인덱스 저장
+    private static int[][] map;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        cnt = new int[4];
+        map = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        getIdx(N / 2, N / 2);
+    }
+
+    // 🐌
+    private static void getIdx(int i, int j) {
+        int[] dxx = {0, 1, 0, -1};
+        int[] dyy = {-1, 0, 1, 0};
+        // shark
+        int pos = 0;
+        int d = 0;
+        int steps = 1;
+        int turned = 0;
+
+        linearIdx = new Point[N * N];
+
+        linearIdx[pos++] = new Point(N / 2, N / 2);
+        while (pos < N * N) {
+            for (int s = 0; s < steps; s++) {
+                i += dxx[d];
+                j += dyy[d];
+
+                linearIdx[pos++] = new Point(i, j);
+
+                if (pos == N * N) {
+                    break;
+                }
+            }
+            d = (d + 1) % 4;
+            if (++turned == 2) {
+                turned = 0;
+                steps++;
+            }
+        }
+    }
+
+    private static void sol() throws IOException {
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            D = Integer.parseInt(st.nextToken());
+            S = Integer.parseInt(st.nextToken());
+
+            enchant();             // Destroy beads
+            pullBeads();           // Fill empty spaces
+            popConsecutiveBeads(); // Explode consecutive beads
+            grouping();
+        }
+        printAns();
+    }
+
+    private static void enchant() {
+        int x = N / 2;
+        int y = N / 2;
+        for (int i = 0; i < S; i++) {
+            x += dx[D];
+            y += dy[D];
+
+            if (OOB(x, y)) {
+                break;
+            }
+            map[x][y] = 0;
+        }
+    }
+
+    private static void pullBeads() {
+        int[][] tmp = new int[N][N];
+
+        int idx = 1; // skip shark
+
+        for (int i = 1; i < N * N; i++) {
+            Point p = linearIdx[i];
+            if (map[p.x][p.y] > 0) {
+                Point to = linearIdx[idx++];
+                tmp[to.x][to.y] = map[p.x][p.y];
+            }
+        }
+        copyArr(tmp, map);
+    }
+
+    private static void makeZero(int start, int end) {
+        for (int i = start; i < end; i++) {
+            Point cur = linearIdx[i];
+            map[cur.x][cur.y] = 0;
+        }
+    }
+
+    private static void popConsecutiveBeads() {
+        boolean popped = true;
+
+        while (popped) {
+            popped = false;
+
+            for (int i = 1; i < N * N; i++) {
+                int number = map[linearIdx[i].x][linearIdx[i].y];
+                int start = i;
+                int count = 1;
+
+                while (i + 1 < N * N
+                        && map[linearIdx[i + 1].x][linearIdx[i + 1].y] == number
+                        && map[linearIdx[i + 1].x][linearIdx[i + 1].y] != 0) {
+                    i++;
+                    count++;
+                }
+
+                if (count >= 4) {
+                    popped = true;
+
+                    cnt[number] += count;
+                    makeZero(start, i + 1);
+                }
+            }
+            if (popped) {
+                pullBeads();
+            }
+        }
+    }
+
+    private static void grouping() {
+        int[][] tmp = new int[N][N];
+
+        int idx = 1; // 상어 다음부터 시작
+        int newIdx = 1; // 새 배열 시작 위치
+
+        while (idx < N * N) {
+            int number = map[linearIdx[idx].x][linearIdx[idx].y];
+
+            // no bead
+            if (number == 0) {
+                break;
+            }
+
+            int count = 0;
+            while (idx < N * N
+                    && map[linearIdx[idx].x][linearIdx[idx].y] == number
+                    && map[linearIdx[idx].x][linearIdx[idx].y] > 0) {
+                idx++;
+                count++;
+            }
+
+            if (newIdx < N * N) {
+                Point countPos = linearIdx[newIdx++];
+                tmp[countPos.x][countPos.y] = count;
+            } else {
+                break;
+            }
+
+            if (newIdx < N * N) {
+                Point typePos = linearIdx[newIdx++];
+                tmp[typePos.x][typePos.y] = number;
+            } else {
+                break;
+            }
+        }
+        copyArr(tmp, map);
+    }
+
+    private static void printAns() {
+        int ans = 0;
+
+        for (int i = 1; i <= 3; i++) {
+            ans += cnt[i] * i;
+        }
+        System.out.println(ans);
+    }
+
+    private static void copyArr(int[][] from, int[][] to) {
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                to[i][j] = from[i][j];
+            }
+        }
+    }
+
+    private static boolean OOB(int x, int y) {
+        return x < 0 || N <= x || y < 0 || N <= y;
+    }
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 n주차 [김민진] 

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **문제 1**
  - [x] **문제 2**  
  - [x] **문제 3**
  - [x] **문제 4**  
  - [x] **문제 5**  

---

## 💡 풀이 방법
### 문제 1: 마법사 상어와 블리자드

**문제 난이도**
골드 1


**문제 유형**
`구현` `시뮬레이션`


 **접근 방식 및 풀이**

📍 `enchant()`: 상어가 얼음을 파괴하는 함수
&nbsp;&nbsp;&nbsp;&nbsp;→ `D` 방향의 얼음을 `S`만큼 0으로 만들기

📍 `pullBeads()`: 빈 칸에 구슬을 당겨 채우는 함수
&nbsp;&nbsp;&nbsp;&nbsp;→ 포인터 두 개 선언하여 빈 칸에 구슬 당겨 넣기
&nbsp;&nbsp;&nbsp;&nbsp;🌟 모든 구슬을 당긴 후 그 뒷부분은 0으로 채워야 함
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;→ 임시 배열 생성하하여 변경된 구슬의 위치를 저장한 후 원본 배열에 복사하는 것으로 해결

📍 `popConsecutiveBeads()`: 동일한 구슬이 4개 이상 붙어있는 경우 제거
&nbsp;&nbsp;&nbsp;&nbsp;→ 포인터 두 개 선언하여 같은 구슬의 시작과 끝을 저장
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- `start`: 시작
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- `i`: 끝

1. 배열의 처음부터 탐색 시작
2. 다른 구슬이 나올때 까지 `i` 증가
3. 2.의 반복문 종료 후 `count`가 4 이상인 경우 `cnt` 배열 업데이트 후 0으로
4. 한 사이클이 끝난 후, 터진 구슬이 있으면 `pullBeads()` 호출
5. 터진 구슬이 없을때까지 반복

📍 `grouping()`: 각 구슬의 수에 따라 `map` 업데이트
&nbsp;&nbsp;&nbsp;&nbsp;→ 포인터 두 개 선언
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- `idx`: 같은 숫자의 구슬 개수를 세는 포인터
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- `newIdx`: 업데이트할 배열의 포인터

1. 배열 탐색
2. 다른 구슬이 나올 때까지 개수 세기
3. 2.의 반복문 종료 후 `newIdx`가 배열 범위를 벗어나지 않으면 `tmp` 업데이트
&nbsp;&nbsp;&nbsp;&nbsp;→ 넘어가면 1. 반복문 종료    
4. `tmp` 배열 `map`에 복사
   
---

### 문제 2: 숫자 카드 

**문제 난이도**
실버 5


 **문제 유형**
`이분 탐색`


 **접근 방식 및 풀이**
이분 탐색으로 안 풀었어요 ㅎ

📍 `cards`: 해당 카드 존재 여부를 저장하는 `boolean` 배열
&nbsp;&nbsp;&nbsp;&nbsp;→ 음수를 처리하기 위해 카드 값에 최대 카드 수를 더하여 인덱싱
```java
    private static final int MAX_NUM = 10_000_000;
    private static final int OFFSET = MAX_NUM;
...
        cards = new boolean[2 * MAX_NUM + 1];
...
        	cards[idx + OFFSET] = true;
...
            sb.append(cards[target + OFFSET] ? "1 " : "0 ");
...
```


---
### 문제 3: 두 배열의 합

**문제 난이도**
골드 3


 **문제 유형**
`이분 탐색` `누적 합`


 **접근 방식 및 풀이**
이것도 이분 탐색으로 안 풀었어요..ㅎ
사실 누적 합 배열도 만들긴 했는데 이 풀이에서 크게 필요한 것 같지는 않은 것 같습니다

1. A 배열을 확인하면서 `map`에 해당 합이 되는 경우가 몇 개인지 기록
&nbsp;&nbsp;&nbsp;&nbsp;→ key값을 부분 배열의 합으로 두고 value는 key값을 만들 수 있는 경우의 수를 저장
```java
for (int i = 1; i <= N; i++) {
	for (int j = i; j <= N; j++) {
		long tmpA = getPartialSum(i, j, A);

		map.put(tmpA, map.getOrDefault(tmpA, 0) + 1);
	}
}
```

2. B 배열을 확인하며 `map.get(key) + B[i:j]`가 `T`가 되는 경우를 `cnt`에 더함
```java
for (int i = 1; i <= M; i++) {
	for (int j = i; j <= M; j++) {
		long tmpB = getPartialSum(i, j, B);

		cnt += map.getOrDefault(T - tmpB, 0);
	}
}
```


---
### 문제 4: 종이 조각

**문제 난이도**
골드 3


 **문제 유형**
`브루트포스` `비트마스킹`


 **접근 방식 및 풀이**

1. 배열 탐색
```java
if (i == N) {
    max = Math.max(max, totalSum());
    visited = new boolean[N][M];
    return;
}

if (j == M) {
    sol(i + 1, 0);
    return;
}
```
→ 이차원 배열을 순차적으로 탐색하기 때문에 행`M` 탐색이 끝나는 경우 다음 열부터 탐색, 모든 칸을 탐색한 경우 열`i`이 `N`이 되므로 그 때 종료

2. 조각의 합 구하기
```java
private static final int HOR = 0; // 오른쪽
private static final int VER = 1; // 아래

private static final int[] dx = {0, 1};
private static final int[] dy = {1, 0};
...
    // horizontal
    pieces[i][j] = true;
    sol(i, j + 1);

    // vertical
    pieces[i][j] = false;
    sol(i, j + 1);
...
    int ni = i;
    int nj = j;

    while (ni < N && nj < M && !visited[ni][nj] && 
          (pieces[ni][nj] ? HOR : VER) == dir) {
        	
        res = res * 10 + nums[ni][nj];
        visited[ni][nj] = true;
            
        ni += dx[dir];
        nj += dy[dir];
    }
...
```
→ `true`인 경우 오른쪽으로, `false`인 경우 아래쪽으로 움직이면서 같은 값일 때 더함
→ 다른 값이 나오는 경우 다른 조각이므로 반복 종료


---
### 문제 5: 강의실 배정

**문제 난이도**
골드 5


 **문제 유형**
`그리디`


 **접근 방식 및 풀이**
회의실 배정 문제 응용 버전이었습니다

1. 1순위 `start`, 2순위 `end` 순서로 정렬
2. 첫 번째 스케쥴의 `end` 값을 우선순위 큐에 넣는다
&nbsp;&nbsp;&nbsp;&nbsp;→ 현재 강의의 끝나는 시간과 다음 강의의 시작하는 시간을 비교하기 때문
3. 배열을 돌면서 현 시점에 가장 빨리 끝나는 강의와 지금 강의의 시간을 비교
&nbsp;&nbsp;&nbsp;&nbsp;→ 자연스럽게 빨리 끝나는 강의 + 그 강의가 끝난 후 가장 먼저 시작하는 강의 조합으로 진행됨
4. `end`가 `start`보다 작거나 같으면 같은 강의실에서 진행 가능
&nbsp;&nbsp;&nbsp;&nbsp;→ `end`를 `poll()` 하고 `start`는 `offer()`
5. 모든 배열을 확인한 후의 우선순위 큐 크기가 정답
&nbsp;&nbsp;&nbsp;&nbsp;→ 회의실 당 맨 마지막에 진행된 강의만 큐에 남음

