### PR TITLE
[김민진-12주차 알고리즘 스터디]

### DIFF
--- a/김민진/12주차/[Baekjoon-1311] 할 일 정하기 1.java
+++ b/김민진/12주차/[Baekjoon-1311] 할 일 정하기 1.java
@@ -1,0 +1,71 @@
+package week12;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Q2TaskScheduling {
+
+    private static final int INF = 987654321;
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static StringTokenizer st;
+
+    private static int N;
+    private static int bitCnt;
+
+    private static int[][] works;
+    private static int[][] dp;    // [i][j: 진행되는 일]: j 일이 진행 중이고 i가 일을 할 때의 최소값
+
+    public static void main(String[] args) throws IOException {
+        init();
+        System.out.println(sol(0, 0));
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine());
+
+        works = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                works[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        bitCnt = (1 << N) - 1; // 모든 일 진행
+        dp = new int[N][bitCnt + 1];
+        for (int i = 0; i < N; i++) {
+            Arrays.fill(dp[i], -1);
+        }
+    }
+
+    private static int sol(int person, int set) {
+        // all asigned
+        if (person == N) {
+            return 0;
+        }
+
+        // alr calculated
+        if (dp[person][set] != -1) {
+            return dp[person][set];
+        }
+
+        int min = INF;
+
+        for (int job = 0; job < N; job++) {
+            // alr working
+            if ((set & (1 << job)) != 0) {
+                continue;
+            }
+
+            int tmp = sol(person + 1, set | (1 << job)) + works[person][job];
+            min = Math.min(tmp, min);
+        }
+
+        return dp[person][set] = min;
+    }
+
+}

--- a/김민진/12주차/[Baekjoon-17144] 미세먼지 안녕!.java
+++ b/김민진/12주차/[Baekjoon-17144] 미세먼지 안녕!.java
@@ -1,0 +1,158 @@
+package week12;
+
+import java.awt.Point;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Q1GoodbyeFineDust {
+
+    private static final int PURIFIER = -1;
+
+    private static final int[] dx = {-1, 1, 0, 0};
+    private static final int[] dy = {0, 0, -1, 1};
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static StringTokenizer st;
+
+    private static int R;
+    private static int C;
+    private static int T;
+
+    private static Point purifier;
+
+    private static int[][] fineDusts;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        R = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+        T = Integer.parseInt(st.nextToken());
+
+        fineDusts = new int[R][C];
+        for (int i = 0; i < R; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < C; j++) {
+                fineDusts[i][j] = Integer.parseInt(st.nextToken());
+
+                // 위쪽 공기청정기 위치 저장
+                if (purifier == null && fineDusts[i][j] == PURIFIER) {
+                    purifier = new Point(i, j);
+                }
+            }
+        }
+    }
+
+    private static void sol() {
+        while (T-- > 0) {
+            spreadDust();
+            purifyAir();
+        }
+        System.out.println(getAns());
+    }
+
+    private static void spreadDust() {
+        int[][] tmp = new int[R][C];
+
+        for (int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                if (fineDusts[i][j] <= 0) {
+                    continue;
+                }
+
+                int cnt = 0;
+                int spreadDust = fineDusts[i][j] / 5;
+                for (int d = 0; d < 4; d++) {
+                    int nx = i + dx[d];
+                    int ny = j + dy[d];
+
+                    if (OOB(nx, ny) || fineDusts[nx][ny] == PURIFIER) {
+                        continue;
+                    }
+                    cnt++;
+                    tmp[nx][ny] += spreadDust;
+                }
+                int left = fineDusts[i][j] - (cnt * spreadDust);
+                tmp[i][j] += left > 0 ? left : 0;
+            }
+        }
+        copyArr(tmp, fineDusts);
+    }
+
+    private static void purifyAir() {
+        // upper
+        // ↓
+        for (int i = purifier.x - 1; i >= 0; i--) {
+            fineDusts[i + 1][0] = fineDusts[i][0];
+        }
+        // ←
+        for (int j = 1; j < C; j++) {
+            fineDusts[0][j - 1] = fineDusts[0][j];
+        }
+        // ↑
+        for (int i = 1; i <= purifier.x; i++) {
+            fineDusts[i - 1][C - 1] = fineDusts[i][C - 1];
+        }
+        // →
+        for (int j = C - 2; j > 0; j--) {
+            fineDusts[purifier.x][j + 1] = fineDusts[purifier.x][j];
+        }
+
+        // lower
+        // ↑
+        for (int i = purifier.x + 1; i < R; i++) {
+            fineDusts[i - 1][0] = fineDusts[i][0];
+        }
+        // ←
+        for (int j = 1; j < C; j++) {
+            fineDusts[R - 1][j - 1] = fineDusts[R - 1][j];
+        }
+        // ↓
+        for (int i = R - 2; i >= purifier.x + 1; i--) {
+            fineDusts[i + 1][C - 1] = fineDusts[i][C - 1];
+        }
+        // →
+        for (int j = C - 2; j > 0; j--) {
+            fineDusts[purifier.x + 1][j + 1] = fineDusts[purifier.x + 1][j];
+        }
+
+        fineDusts[purifier.x][purifier.y] = -1;
+        fineDusts[purifier.x + 1][purifier.y] = -1;
+        // 공청기에서 나온 바람
+        fineDusts[purifier.x][1] = 0;
+        fineDusts[purifier.x + 1][1] = 0;
+    }
+
+    private static void copyArr(int[][] from, int[][] to) {
+        for (int i = 0; i < R; i++) {
+            System.arraycopy(from[i], 0, to[i], 0, C);
+        }
+        fineDusts[purifier.x][purifier.y] = -1;
+        fineDusts[purifier.x + 1][purifier.y] = -1;
+    }
+
+    private static int getAns() {
+        int ans = 0;
+
+        for (int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                if (fineDusts[i][j] >= 0) {
+                    ans += fineDusts[i][j];
+                }
+            }
+        }
+        return ans;
+    }
+
+    private static boolean OOB(int x, int y) {
+        return x < 0 || R <= x || y < 0 || C <= y;
+    }
+
+}

--- a/김민진/12주차/[Baekjoon-21924] 도시 건설.java
+++ b/김민진/12주차/[Baekjoon-21924] 도시 건설.java
@@ -1,0 +1,109 @@
+package week12;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Q4BuildingCity {
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static StringTokenizer st;
+
+    private static int N;
+    private static int M;
+    private static long total;
+    private static long ans;
+
+    private static boolean visited[];
+
+    private static Queue<Node> pq;
+    private static List<Node>[] graph;
+
+    private static class Node implements Comparable<Node> {
+
+        int to;
+        int dist;
+
+        public Node(int to, int dist) {
+            this.to = to;
+            this.dist = dist;
+        }
+
+        @Override
+        public int compareTo(Node o) {
+            return Integer.compare(this.dist, o.dist);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        total = 0;
+        ans = 0;
+
+        graph = new ArrayList[N + 1];
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            int dist = Integer.parseInt(st.nextToken());
+
+            graph[from].add(new Node(to, dist));
+            graph[to].add(new Node(from, dist));
+
+            total += dist;
+        }
+
+        visited = new boolean[N + 1];
+        pq = new PriorityQueue<>();
+    }
+
+    private static void sol() {
+        pq.offer(new Node(1, 0));
+
+        while (!pq.isEmpty()) {
+            Node cur = pq.poll();
+
+            if (visited[cur.to]) {
+                continue;
+            }
+
+            visited[cur.to] = true;
+            ans += cur.dist;
+
+            for (Node nxt : graph[cur.to]) {
+                if (visited[nxt.to]) {
+                    continue;
+                }
+
+                pq.offer(nxt);
+            }
+        }
+
+        for (int i = 1; i <= N; i++) {
+            if (!visited[i]) {
+                System.out.println(-1);
+                System.exit(0);
+            }
+        }
+        System.out.println(total - ans);
+    }
+
+}

--- a/김민진/12주차/[Baekjoon-2405] 세 수, 두 M.java
+++ b/김민진/12주차/[Baekjoon-2405] 세 수, 두 M.java
@@ -1,0 +1,56 @@
+package week12;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Q3ThreeNumbersTwoM {
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    private static int N;
+    private static int ans;
+    private static int[] nums;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        sol();
+    }
+
+    private static void init() throws IOException {
+        N = Integer.parseInt(br.readLine().trim());
+        ans = 0;
+
+        nums = new int[N];
+        for (int i = 0; i < N; i++) {
+            nums[i] = Integer.parseInt(br.readLine().trim());
+        }
+        Arrays.sort(nums);
+    }
+
+    /*
+     * |b - (a + b + c)/3| × 3
+     * = |(3b - a - b - c)/3| × 3
+     * = |(2b - a - c)/3| × 3
+     * = |2b - a - c|
+     */
+    private static void sol() {
+        int gap;
+
+        for (int i = 1; i < N - 1; i++) {
+            gap = Math.abs(2 * nums[i] - nums[0] - nums[i + 1]);
+            ans = Math.max(ans, gap);
+
+            gap = Math.abs(2 * nums[i] - nums[i - 1] - nums[N - 1]);
+            ans = Math.max(ans, gap);
+        }
+        System.out.println(ans);
+    }
+
+    /*
+     * [-100, 0, 1, 2, 100]
+     * 최소, 최대 둘 다 포함: |2 * 1 - (-100) - 100| = |2 + 100 - 100| = 2
+     * 하나만 포함, 두 수는 붙임: |2 * 0 - (-100) - 1| = |0 + 100 - 1| = 99
+     */
+}

--- a/김민진/12주차/[Baekjoon-7511] 소셜 네트워킹 애플리케이션.java
+++ b/김민진/12주차/[Baekjoon-7511] 소셜 네트워킹 애플리케이션.java
@@ -1,0 +1,78 @@
+package week12;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Q5SocialNetworkingApplication {
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final StringBuilder sb = new StringBuilder();
+    private static StringTokenizer st;
+
+    private static int N; // users
+    private static int K; // relations
+    private static int M;
+
+    private static int[] parents;
+
+    public static void main(String[] args) throws IOException {
+        int T = Integer.parseInt(br.readLine().trim());
+
+        for (int tc = 1; tc <= T; tc++) {
+            sb.append("Scenario ").append(tc).append(":\n");
+            sol();
+        }
+        System.out.println(sb);
+    }
+
+    private static void sol() throws IOException {
+        N = Integer.parseInt(br.readLine().trim());
+        K = Integer.parseInt(br.readLine().trim());
+
+        parents = new int[N + 1];
+        for (int i = 1; i <= N; i++) {
+            parents[i] = i;
+        }
+
+        while (K-- > 0) {
+            st = new StringTokenizer(br.readLine());
+
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            union(a, b);
+        }
+
+        M = Integer.parseInt(br.readLine().trim());
+        while (M-- > 0) {
+            st = new StringTokenizer(br.readLine());
+
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            sb.append(find(a) == find(b) ? "1\n" : "0\n");
+        }
+        sb.append("\n");
+    }
+
+    private static void union(int a, int b) {
+        int rootA = find(a);
+        int rootB = find(b);
+
+        if (rootA < rootB) {
+            parents[rootB] = rootA;
+        } else {
+            parents[rootA] = rootB;
+        }
+    }
+
+    private static int find(int a) {
+        if (parents[a] == a) {
+            return a;
+        }
+        return parents[a] = find(parents[a]);
+    }
+
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 12주차 [김민진] 

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **문제 1**
  - [x] **문제 2**  
  - [x] **문제 3**
  - [x] **문제 4**  
  - [x] **문제 5**  

---

## 💡 풀이 방법
### 문제 1: 미세먼지 안녕!


**문제 난이도**
골드 4


**문제 유형**
`구현` `시뮬레이션`


 **접근 방식 및 풀이**
1. `spreadDust()`
  : 미세먼지가 있는 칸 사방에 문제에서 요구한 만큼의 모래를 퍼뜨리는 함수
  : 모래가 퍼질 수 있는 모든 방향에 먼지를 퍼뜨리나 원래의 칸에 먼지가 남지 않는다면 퍼뜨리지 말 것

2. `purifyAir()`
  : 각 공기청정기의 방향에 맞게 모래 이동
  : 공기청정기가 뱉은 공기는 미세먼지가 없는 점 유의할 것

   
---
### 문제 2: 할 일 정하기 

**문제 난이도**
골드 1


 **문제 유형**
`비트마스킹` `DP`


 **접근 방식 및 풀이**
외판원 문제를 비트마스킹 DP로 풀 때와 유사한 것 같습니다

1. DP 배열 -1로 초기화
  ```java
DP[i][j] = j의 일이 진행되는 동안 i가 일을 하고 있는 경우
// j: 총 작업을 비트로 관리(0: 진행 X / 1: 진행 O)
```
2. 모든 일이 할당된 경우 혹은 이전에 확인한 경우 처리
3. 최소값 찾기
  : 최소값을 구하기 위해 DP 배열의 값을 `INF`로 변경
  : 이미 직업이 할당된 경우 건너뛰기
  : 작업이 할당되지 않은 경우 작업 할당 후 기존 값과 비교

---
### 문제 3: 세 수, 두 M

**문제 난이도**
골드 4

 
 **문제 유형**
`수학` `그리디` `정렬`


 **접근 방식 및 풀이**
처음에는 1. 최소값 + 두 번째로 작은 값 + 최대값, 2. 최소값 + 두 번째로 큰 값 + 최대값을 비교했는데 음수 포함이라 실패했습니다🙂🙃🙂🙃
음수를 고려하면 최소값 혹은 최대값을 하나만 고정하고 붙어있는 두 수를 확인해야합니다.

📍 소수점 연산 오차 해결
```
|b - (a + b + c)/3| * 3
= |(3b - a - b - c)/3| * 3
= |(2b - a - c)/3| * 3
= |2b - a - c|
```

---
### 문제 4: 도시 건설

**문제 난이도**
골드 4

 
 **문제 유형**
`그래프` `MST`


 **접근 방식 및 풀이**
전형적인 MST 문제였는데 절약한 비용을 출력해야하는 걸 최소 비용을 출력해서 계속 틀렸습니다,,
PRIM 알고리즘을 사용했기 때문에 확인이 끝난 후 방문하지 못 한 노드가 있으면 -1, 모두 방문 했으면 (모든 비용) - (최소 비용)을 출력하면 됩니다.


---
### 문제 5: 소셜 네트워킹 애플리케이션

**문제 난이도**
골드 5
 

 **문제 유형**
`Union-Find`


 **접근 방식 및 풀이**
전형적인 Union-Find 문제입니다.
